### PR TITLE
bash_completion error for -h

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -32,7 +32,7 @@ _aurget() {
     *$aurget) COMPREPLY=($(compgen -W "$allopts" -- $cur)) ;;
 
     # don't complete beyond these
-    -h|--@(help|ignore) return 0 ;;
+    -h|--@(help|ignore)) return 0 ;;
 
     # complete with long opts
     -S*u*|--*) COMPREPLY=($(compgen -W "$longopts" -- $cur)) ;;


### PR DESCRIPTION
Hi.
After updating aurget and spawning a new shell I got the following error:

```
bash: /etc/bash_completion.d/aurget: line 35: syntax error near unexpected token `return'
bash: /etc/bash_completion.d/aurget: line 35: `    -h|--@(help|ignore) return 0 ;;'
```

This patch should fix it.
