### PR TITLE
fix url_encode for packages with underscores

### DIFF
--- a/aurget
+++ b/aurget
@@ -74,10 +74,10 @@ debug() {
 url_encode() {
   hexdump -v -e '1/1 "%02x\t"' -e '1/1 "%_c\n"' <<< "$*" \
     | LANG=C awk '
-      $1 == "20"                   { printf("%s", "+"); next }
-      $1 ~  /0[adAD]/              {                    next }
-      $2 ~  /^[a-zA-Z0-9.*()\/-]$/ { printf("%s", $2);  next }
-                                   { printf("%%%s", $1)      }
+      $1 == "20"                    { printf("%s", "+"); next }
+      $1 ~  /0[adAD]/               {                    next }
+      $2 ~  /^[a-zA-Z0-9.*()\/_-]$/ { printf("%s", $2);  next }
+                                    { printf("%%%s", $1)      }
     '
 }
 


### PR DESCRIPTION
fixed the url_encode function for packages with underscores.

```
$ aurget --debug acpi_call-git
[DEBUG] setting up 1 targets for processing
:: Searching AUR...
[DEBUG] HTTP GET https://aur.archlinux.org/rpc.php?type=multiinfo&arg\[\]=acpi0.000000call-git
error: target not found: acpi_call-git
```
