### PR TITLE
Feature Request: keep some package sources via config

### DIFF
--- a/aurget
+++ b/aurget
@@ -133,6 +133,8 @@ parse_rpc() {
   '
 }
 
+keep_sources() { [[ "$1" =~ "$keep_source_packages" ]]; }
+
 is_devel() { [[ "$1" =~ -(git|hg|svn|darcs|csv|bzr)$ ]]; }
 
 is_ignored() { [[ " $ignore_packages " =~ " $1 " ]]; }
@@ -277,6 +279,7 @@ set_defaults() {
   discard_sources=true
   ignore_packages=''
   keep_devels=true
+  keep_source_packages=''
   makepkg='makepkg'
   makepkg_options='--syncdeps'
   noconfirm=false
@@ -584,6 +587,11 @@ discard_sources() {
 
   if ! $discard_sources; then
     debug "keeping sources for $colorG$name$nocolor (discard false)"
+    return
+  fi
+
+  if keep_sources "$name"; then
+    debug "keeping sources for $colorG$name$nocolor (keep sources)"
     return
   fi
 

--- a/aurgetrc
+++ b/aurgetrc
@@ -26,6 +26,10 @@ ignore_packages=''
 # discard sources for development packages.
 keep_devels=true
 
+# A regex for packages to keep the sources for,
+# regardless of discard_sources.
+keep_source_packages=''
+
 # The makepkg executable
 makepkg='makepkg'
 


### PR DESCRIPTION
In the 3.\* versions I modified development_regex to include some non-development packages for which the source should be kept. This is no longer possible, since the variable was inlined.

Thus I propose a keep_source_packages config-option to specify packages, for which the sources should be kept.
