### PR TITLE
added tests for zsh

### DIFF
--- a/.cramrc
+++ b/.cramrc
@@ -1,2 +1,1 @@
 [cram]
-shell = bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python: "2.7"
 
 install:
   - pip install cram
-  - sudo apt-get zsh
+  - sudo apt-get install zsh
 
 script:
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python: "2.7"
 
 install:
   - pip install cram
+  - sudo apt-get zsh
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ doc/aurgetrc.5: doc/aurgetrc.5.md
 man: doc/aurget.1 doc/aurgetrc.5
 
 test:
-	cram test
+	cram --shell=bash test
+	cram --shell=zsh test
 
 install:
 	install -Dm755 aurget $(DESTDIR)/$(PREFIX)/bin/aurget


### PR DESCRIPTION
Since aurget is a bash script that is also supposed to work zsh, test should be run on zsh as well. I barely know cram and I could not figure out whether there is a better way to test on different shells.

Is there a reason not to execute those tests on bash and zsh?