### PR TITLE
Compatibility with AUR4

### DIFF
--- a/aurget
+++ b/aurget
@@ -3,7 +3,7 @@
 # pbrisbin 2013
 #
 ###
-AUR='https://aur.archlinux.org'
+AUR='https://aur4.archlinux.org' # to be changed back to the aur-subdomain on 2015-08-08
 
 # Message {{{
 message() {
@@ -81,7 +81,6 @@ debug() {
 url_encode() {
   hexdump -v -e '1/1 "%02x\t"' -e '1/1 "%_c\n"' <<< "$*" \
     | LANG=C awk '
-      $1 == "20"                    { printf("%s", "+"); next }
       $1 ~  /0[adAD]/               {                    next }
       $2 ~  /^[a-zA-Z0-9.*()\/_-]$/ { printf("%s", $2);  next }
                                     { printf("%%%%%s", $1)    }
@@ -89,7 +88,7 @@ url_encode() {
 }
 
 aur_packages_url() {
-  printf "$AUR/packages/$(url_encode "${1:0:2}")/$(url_encode "$1")\n"
+  printf "$AUR/cgit/aur.git\n"
 }
 
 aur_search_url() {
@@ -108,9 +107,9 @@ aur_info_url() {
 
 get() { debug "HTTP GET $colorM$1$nocolor"; curl --silent --fail "$1"; }
 
-pkgbuild() { get "$(aur_packages_url "$1")/PKGBUILD"; }
+pkgbuild() { get "$(aur_packages_url)/plain/PKGBUILD?h=$1"; }
 
-taurball() { get "$(aur_packages_url "$1")/${1}.tar.gz"; }
+taurball() { get "$(aur_packages_url)/snapshot/$(url_encode "$1").tar.gz"; }
 
 rpc_search() { get "$(aur_search_url "$1")" | parse_rpc | sort_rpc; }
 
@@ -615,7 +614,6 @@ process_targets() {
       fi
     else
       debug "extracting $colorG$pkgbase$nocolor directly"
-
       if ! taurball "$pkgbase" | tar xfz -; then
         if (( ${target_deps[$pkgbase]} )); then
           die "dependency package $pkgbase failed to download, aborting"

--- a/aurget
+++ b/aurget
@@ -3,7 +3,8 @@
 # pbrisbin 2013
 #
 ###
-AUR='https://aur4.archlinux.org' # to be changed back to the aur-subdomain on 2015-08-08
+AUR3='https://aur.archlinux.org'
+AUR4='https://aur4.archlinux.org'
 
 # Message {{{
 message() {
@@ -28,6 +29,9 @@ Usage: aurget [ -h | -S* [ --options ] [ -- ] <arguments> ]
         -Ssq <term>     search aur for <term>, print only package names
         -Sp  <package>  print the PKGBUILD for <package>
         -Si  <package>  print extended info for <package>
+
+        --aur3          use the AUR3 ($AUR3)
+        --aur4          use the AUR4 ($AUR4)
 
         --sort <name|votes>
                         sort search output by name (ascending) or votes
@@ -87,12 +91,18 @@ url_encode() {
     '
 }
 
-aur_packages_url() {
-  printf "$AUR/cgit/aur.git\n"
+aur_url() { $use_aur4 && printf "$AUR4\n" || printf "$AUR3\n"; }
+
+aur3_packages_url() {
+  printf "$AUR3/packages/$(url_encode "${1:0:2}")/$(url_encode "$1")\n"
+}
+
+aur4_packages_url() {
+  printf "$AUR4/cgit/aur.git\n"
 }
 
 aur_search_url() {
-  printf "$AUR/rpc.php?type=search&arg=$(url_encode "$1")\n"
+  printf "$(aur_url)/rpc.php?type=search&arg=$(url_encode "$1")\n"
 }
 
 aur_info_url() {
@@ -102,14 +112,26 @@ aur_info_url() {
     params+="&arg\[\]=$(url_encode "$arg")"
   done
 
-  printf "$AUR/rpc.php?type=multiinfo$params\n"
+  printf "$(aur_url)/rpc.php?type=multiinfo$params\n"
 }
 
 get() { debug "HTTP GET $colorM$1$nocolor"; curl --silent --fail "$1"; }
 
-pkgbuild() { get "$(aur_packages_url)/plain/PKGBUILD?h=$(url_encode "$1")"; }
+pkgbuild() {
+if $use_aur4; then
+  get "$(aur4_packages_url)/plain/PKGBUILD?h=$(url_encode "$1")"
+else
+  get "$(aur3_packages_url "$1")/PKGBUILD"
+fi
+}
 
-taurball() { get "$(aur_packages_url)/snapshot/$(url_encode "$1").tar.gz"; }
+taurball() {
+if $use_aur4; then
+  get "$(aur4_packages_url)/snapshot/$(url_encode "$1").tar.gz";
+else
+  get "$(aur3_packages_url "$1")/$(url_encode "$1").tar.gz";
+fi
+}
 
 rpc_search() { get "$(aur_search_url "$1")" | parse_rpc | sort_rpc; }
 
@@ -280,6 +302,8 @@ initialize() {
       -Ssq|-Sqs)     opmode='search' ; search_mode='quiet'           ;;
       -Si|-Ssi|-Sis) opmode='search' ; search_mode='info'            ;;
       -Sp|-Ssp|-Sps) opmode='search' ; search_mode='print'           ;;
+      --aur3)        use_aur4=false                                  ;;
+      --aur4)        use_aur4=true                                   ;;
       --builddir)    shift; build_directory="$1"                     ;;
       --ignore)      shift; ignore_packages+=" $1"                   ;;
       --noconfirm)   noconfirm=true; makepkg_options+=' --noconfirm' ;;
@@ -310,6 +334,7 @@ initialize() {
 
 set_defaults() {
   build_directory="$PWD"
+  use_aur4=false
   debug=false
   devels=false
   disable_color=false

--- a/aurget
+++ b/aurget
@@ -107,7 +107,7 @@ aur_info_url() {
 
 get() { debug "HTTP GET $colorM$1$nocolor"; curl --silent --fail "$1"; }
 
-pkgbuild() { get "$(aur_packages_url)/plain/PKGBUILD?h=$1"; }
+pkgbuild() { get "$(aur_packages_url)/plain/PKGBUILD?h=$(url_encode "$1")"; }
 
 taurball() { get "$(aur_packages_url)/snapshot/$(url_encode "$1").tar.gz"; }
 
@@ -614,6 +614,7 @@ process_targets() {
       fi
     else
       debug "extracting $colorG$pkgbase$nocolor directly"
+
       if ! taurball "$pkgbase" | tar xfz -; then
         if (( ${target_deps[$pkgbase]} )); then
           die "dependency package $pkgbase failed to download, aborting"

--- a/aurget
+++ b/aurget
@@ -85,6 +85,7 @@ debug() {
 url_encode() {
   hexdump -v -e '1/1 "%02x\t"' -e '1/1 "%_c\n"' <<< "$*" \
     | LANG=C awk '
+      $1 == "20"                    { printf("%s", "+"); next }
       $1 ~  /0[adAD]/               {                    next }
       $2 ~  /^[a-zA-Z0-9.*()\/_-]$/ { printf("%s", $2);  next }
                                     { printf("%%%%%s", $1)    }

--- a/aurgetrc
+++ b/aurgetrc
@@ -12,6 +12,9 @@
 #
 ###
 
+# Whether to use AUR4 instead of AUR3.
+use_aur4=false
+
 # The directory within which to build.
 build_directory="$PWD"
 

--- a/doc/aurget.1
+++ b/doc/aurget.1
@@ -78,6 +78,16 @@ Print information about the given package\.
 .SH OPTIONS
 .LP
 .TP
+\fB--aur3\fR
+Use the AUR3 (https://aur\.archlinux\.org), which is the default\.
+.LP
+.TP
+\fB--aur4\fR
+Use the AUR4 (https://aur4\.archlinux\.org) instead of AUR3\. This will 
+become the default on 2015-08-08, when the AUR4 will move to the 
+aur-subdomain\.
+.LP
+.TP
 \fB--sort\fR \fIMODE\fP
 Set the mode for sorting of search results\. When \fIname\fP, sort the 
 results by Name ascending\. When \fIvotes\fP, sort the results by Number of 

--- a/doc/aurget.1.md
+++ b/doc/aurget.1.md
@@ -59,6 +59,15 @@ multiple actions are passed, the last specified is used.
 
 ## OPTIONS
 
+`--aur3`
+  Use the AUR3 (https://aur.archlinux.org), which is the default.
+
+`--aur4`
+  Use the AUR4 (https://aur4.archlinux.org) instead of AUR3. This will 
+  become the default on 2015-08-08, when the AUR4 will move to the 
+  aur-subdomain.
+
+
 `--sort` *MODE*
   Set the mode for sorting of search results. When *name*, sort the 
   results by Name ascending. When *votes*, sort the results by Number of 

--- a/doc/aurgetrc.5
+++ b/doc/aurgetrc.5
@@ -28,6 +28,13 @@ An example can be found at \fB/usr/share/doc/aurget/samples/aurgetrc\fR\.
 .SH VARIABLES
 .LP
 .TP
+\fBuse_aur4\fR \fItrue\fP\[or]\fIfalse\fP
+Use the AUR4 (https://aur4\.archlinux\.org) instead of the old AUR3 
+(https://aur\.archlinux\.org)\. Default is \fBfalse\fR\. Note that this 
+will become obsolete on 2015-08-08 when the AUR4 will move to the 
+aur-sobdomain\.
+.LP
+.TP
 \fBbuild_directory\fR \fIDIRECTORY\fP
 The directory within which to build\. Default is current directory\.
 .LP
@@ -52,7 +59,7 @@ When to present PKGBUILDs for editing\. Default is \fBprompt\fR\.
 .LP
 .TP
 \fBignore_packages\fR \fIPACKAGE PACKAGE ...\fP
-Packages to ignore\. Default is unset
+Packages to ignore\. Default is unset\.
 .LP
 .TP
 \fBkeep_devels\fR \fItrue\fP\[or]\fIfalse\fP

--- a/doc/aurgetrc.5.md
+++ b/doc/aurgetrc.5.md
@@ -20,6 +20,12 @@ An example can be found at `/usr/share/doc/aurget/samples/aurgetrc`.
 
 ## VARIABLES
 
+`use_aur4` *true*|*false*
+  Use the AUR4 (https://aur4.archlinux.org) instead of the old AUR3
+  (https://aur.archlinux.org). Default is `false`. Note that this
+  will become obsolete on 2015-08-08 when the AUR4 will move to the
+  aur-sobdomain.
+
 `build_directory` *DIRECTORY*
   The directory within which to build. Default is current directory.
 
@@ -40,7 +46,7 @@ An example can be found at `/usr/share/doc/aurget/samples/aurgetrc`.
   When to present PKGBUILDs for editing. Default is `prompt`.
 
 `ignore_packages` *PACKAGE PACKAGE ...*
-  Packages to ignore. Default is unset
+  Packages to ignore. Default is unset.
 
 `keep_devels` *true*|*false*
   If you choose to discard sources, you can separately choose to NOT 


### PR DESCRIPTION
The release of aurweb4 has changed the AUR significantly.
So have the URL's, which I therefore have changed in the script.
Furthermore I have removed the special URL-encoding practice of <SPACE>, '+', and thereby changed it to the default '%20'.
I also added a missing call to url_encode(), although I'm still not sure whether this is needed - at least for a simple SYNC-operation (-S[^si]).