### PR TITLE
feat: Add possibility to disable maintainance warning

### DIFF
--- a/aurget
+++ b/aurget
@@ -402,6 +402,7 @@ set_defaults() {
   sort_mode='name'
   sync_mode='install'
   temp_directory='/tmp/aurget'
+  disable_maintenance_warning=false
   user_config="${XDG_CONFIG_HOME:-$HOME/.config}/aurgetrc"
 
   EDITOR="${EDITOR:-$VISUAL}"
@@ -797,10 +798,12 @@ declare -A targets         # pkgbase->name(s)
 declare -A target_versions # name->version
 declare -A target_deps     # pkgbase->is-dep?
 
-warn "aurget is no longer being maintained, if you would like to volunteer please communicate your interest on this GitHub Issue: https://github.com/pbrisbin/aurget/issues/66"
-sleep 1
-
 initialize "$@"
+
+if [[ ! "$disable_maintenance_warning" == "true" ]]; then
+  warn "aurget is no longer being maintained, if you would like to volunteer please communicate your interest on this GitHub Issue: https://github.com/pbrisbin/aurget/issues/66. You can disable this warning by setting disable_maintenance_warning=true in your aurgetrc."
+  sleep 1
+fi
 
 if searching; then
   perform_search

--- a/aurgetrc
+++ b/aurgetrc
@@ -55,6 +55,9 @@ sync_mode='install'
 # directory is created and cleared when aurget starts.
 temp_directory='/tmp/aurget'
 
+# Disable warning that aurget is no longer maintained
+disable_maintenance_warning=false
+
 # Colors
 colorR="\e[1;31m"
 colorG="\e[1;32m"

--- a/doc/aurgetrc.5
+++ b/doc/aurgetrc.5
@@ -90,6 +90,11 @@ How to process packages\. Default is \fBinstall\fR\.
 \fBtemp_directory\fR \fIDIRECTORY\fP
 Where to place temporary files\. Default is \fB/tmp/aurget\fR\.
 .LP
+.TP
+\fBdisable_maintenance_warning\fR \fItrue\fP\[or]\fIfalse\fP
+Disable warning that aurget is no longer maintained. Default is 
+\fBfalse\fR\.
+.LP
 .SH COLORS
 .LP
 .TP

--- a/doc/aurgetrc.5.md
+++ b/doc/aurgetrc.5.md
@@ -70,6 +70,10 @@ An example can be found at `/usr/share/doc/aurget/samples/aurgetrc`.
 `temp_directory` *DIRECTORY*
   Where to place temporary files. Default is `/tmp/aurget`.
 
+`disable_maintenance_warning` *true*|*false*
+   Disable warning that aurget is no longer maintained. Default is 
+  `false`.
+
 ## COLORS
 
 `colorR` *ANSI ESCAPE*


### PR DESCRIPTION
If you have noted the message I think one should be able to disable it. At least the `sleep 1`.

Not sure if some tests are needed for this?